### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @DanXu-ChinaTelecom @Jason-ZTE @alpaycetin74 @olsi-korkuti
+* @DanXu-ChinaTelecom @Jason-ZTE @alpaycetin74
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @DanXu-ChinaTelecom @Jason-ZTE
+* @DanXu-ChinaTelecom @Jason-ZTE @alpaycetin74 @olsi-korkuti
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins


### PR DESCRIPTION
Add 1 member of VF Group Plc to the list of code owners

#### What type of PR is this?
subproject management

#### What this PR does / why we need it:
Add 1 member of VF Group Plc to the list of code owners, to improve engagement on the subproject.

#### Which issue(s) this PR fixes:
Fixes https://github.com/camaraproject/VerifiedCaller/issues/17

#### Special notes for reviewers:
-

#### Changelog input
Add 1 member of VF Group Plc to the list of code owners

#### Additional documentation 
-