### PR TITLE
Quobis Codeowner proposal

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @DanXu-ChinaTelecom @Jason-ZTE @alpaycetin74
+* @DanXu-ChinaTelecom @Jason-ZTE @alpaycetin74 @stroncoso-quobis
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management

#### What this PR does / why we need it:

Add 1 vendor of Quobis to CODEOWNERS.

He is already a participant as CODEOWNER at CAMARA WebRTC subgroup. Willing to provide experience on CAMARA release management, an independat-vendor technical view and dedicated time to provide code contributions.

#### Which issue(s) this PR fixes:

Related with #17 

#### Special notes for reviewers:

n/a

#### Changelog input

```
 release-note
* Add 1 vendor member ofto the list of code owners
```

#### Additional documentation 

n/a
