### PR TITLE
Add call-branded event notifications to brand-registration API

### DIFF
--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -21,6 +21,10 @@ info:
     * **displayAsset**: A visual asset (e.g. a logo, image or video) that is to be displayed to the callee on their device screen instead of the calling number. Support of the visual asset depends on the service provider and callee's device. If the service provider does not support the parameter, it SHALL clearly document the limitation and SHOULD silently ignore the parameter if received.
     * **customerId** : A string to represent the owner of the displayName, e.g. a commercial brand or an institution.
     * **verifyCallerAction**: An instruction applied during actual call setup. Indicates the action to be taken by the service provider if the authenticity of the caller cannot be established using VerifiedCaller API capabilities.
+    * **Notification URL and token**: Developers may provide a callback URL (`sink`) for receiving an async response.
+    This is an optional parameter. If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential`
+    property to protect the notification endpoint. In the current version,`sinkCredential.credentialType` MUST be set to `ACCESSTOKEN` if provided.
+    
     # API Functionality
 
     The API exposes the following endpoints/operations:

--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -21,9 +21,8 @@ info:
     * **displayAsset**: A visual asset (e.g. a logo, image or video) that is to be displayed to the callee on their device screen instead of the calling number. Support of the visual asset depends on the service provider and callee's device. If the service provider does not support the parameter, it SHALL clearly document the limitation and SHOULD silently ignore the parameter if received.
     * **customerId** : A string to represent the owner of the displayName, e.g. a commercial brand or an institution.
     * **verifyCallerAction**: An instruction applied during actual call setup. Indicates the action to be taken by the service provider if the authenticity of the caller cannot be established using VerifiedCaller API capabilities.
-    * **Notification URL and token**: Developers may provide a callback URL (`sink`) for receiving an async response.
-    This is an optional parameter. If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential`
-    property to protect the notification endpoint. In the current version,`sinkCredential.credentialType` MUST be set to `ACCESSTOKEN` if provided.
+    * **Notification URL and token**:  The API consumer may provide a callback URL (`sink`) on which notifications about events related to given brand registration(eg. calls with brand information) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message.
+    If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint. In the current version, `sinkCredential.credentialType` MUST be set to `ACCESSTOKEN` if `sinkCredential` is provided or to `PRIVATE_KEY_JWT` if authentication information is pre-shared.
     
     # API Functionality
 

--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -23,7 +23,7 @@ info:
     * **verifyCallerAction**: An instruction applied during actual call setup. Indicates the action to be taken by the service provider if the authenticity of the caller cannot be established using VerifiedCaller API capabilities.
     * **Notification URL and token**:  The API consumer may provide a callback URL (`sink`) on which notifications about events related to given brand registration(eg. calls with brand information) can be received from the API provider. This is an optional parameter. The notification will be sent as a CloudEvent compliant message.
     If `sink` is included, it is RECOMMENDED for the client to provide as well the `sinkCredential` property to protect the notification endpoint. In the current version, `sinkCredential.credentialType` MUST be set to `ACCESSTOKEN` if `sinkCredential` is provided or to `PRIVATE_KEY_JWT` if authentication information is pre-shared.
-    
+
     # API Functionality
 
     The API exposes the following endpoints/operations:

--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -649,10 +649,12 @@ components:
       type: object
       description: |
         Event payload describing a successfully branded call.
-        The CloudEvent envelope's `source` carries the registration URL
-        (which encodes the `registrationId`) and `time` carries when the
-        call was branded — see the parent `BrandRegistrationNotificationEvent`.
+        The CloudEvent envelope's `time` carries when the call was branded.
+      required:
+        - registrationId
       properties:
+        registrationId:
+          $ref: '#/components/schemas/RegistrationId'
         strategy:
           type: string
           enum:
@@ -670,7 +672,7 @@ components:
             in the `AnnouncementInfo` response of `POST /pre-announce` (verified-caller API).
             Present when pre-announcement was used to initiate the branded call.
             Absent when the call was branded automatically without pre-announcement
-            (e.g. via `verifyCallerAction` configured at registration).
+            (e.g. no `verifyCallerAction` was configured at registration).
           example: "9e765f76-8037-4e5f-ba5d-e0c87c09a320"
 
     CloudEvent:
@@ -723,10 +725,11 @@ components:
       maxLength: 2048
       description: |
         Identifies the context in which the event happened. For Brand Registration
-        events, this MUST be the GET-able URL of the specific registration the
-        event pertains to, in the format
-        `{apiRoot}/brand-registration/{version}/registrations/{registrationId}`.
-      example: "https://service-provider.com/brand-registration/v0/registrations/ea77c42f-fa5e-4612-cb43-d502ae794832"
+        events, this MUST be the URL of the brand-registrations collection of the
+        API provider, in the format
+        `{apiRoot}/brand-registration/{version}/registrations`.
+        The specific `registrationId` the event pertains to is carried in `data.registrationId`.
+      example: "https://service-provider.com/brand-registration/v0/registrations"
 
     SinkCredential:
       type: object
@@ -1247,12 +1250,13 @@ components:
       description: Notification emitted when a call associated with a brand registration has been successfully branded.
       value:
         id: "83a0cf3a-f3ae-4f3b-9d3b-1e19c6e7f8a0"
-        source: "https://service-provider.com/brand-registration/v0/registrations/ea77c42f-fa5e-4612-cb43-d502ae794832"
+        source: "https://service-provider.com/brand-registration/v0/registrations"
         specversion: "1.0"
         type: "org.camaraproject.brand-registration.v0.call-branded"
         datacontenttype: "application/json"
         time: "2026-04-22T14:30:00Z"
         data:
+          registrationId: "ea77c42f-fa5e-4612-cb43-d502ae794832"
           strategy: "BRAND_DISPLAY"
           displayNameUsed: "Company X Calling"
           preAnnouncementId: "9e765f76-8037-4e5f-ba5d-e0c87c09a320"

--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -57,7 +57,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  x-camara-commonalities: 0.6
+  x-camara-commonalities: 0.7.0
 externalDocs:
   description: Project documentation at Camara
   url: https://github.com/camaraproject/VerifiedCaller
@@ -76,6 +76,8 @@ tags:
     description: Read Existing Brand Registration Information for a Calling Party
   - name: Delete Brand registration
     description: Delete Existing Brand Registration Information for a Calling Party
+  - name: Call branded notifications callback
+    description: Notifications callback invoked by the API provider when a call is successfully branded for a registration that opted in with `sink`.
 paths:
   /registrations:
     post:
@@ -113,6 +115,81 @@ paths:
                   displayAsset: "https://ims.operator-name.com/brand-logo.bmp;purpose=icon"
                   customerId: "Customer2"
                   verifyCallerAction: "DO_NOT_BRAND"
+              INPUT_WITH_NOTIFICATIONS_ACCESSTOKEN:
+                summary: Registration with notifications (ACCESSTOKEN credential)
+                description: |
+                  Create a registration and opt in for CloudEvent notifications.
+                  The API provider will call the `sink` URL with a bearer token when a call is branded.
+                value:
+                  phoneNumber: "+123456789"
+                  terminatingCountryCode: 44
+                  displayName: "Company X Calling"
+                  customerId: "Customer1"
+                  verifyCallerAction: "DO_NOT_BRAND"
+                  sink: "https://endpoint.example.com/sink"
+                  sinkCredential:
+                    credentialType: "ACCESSTOKEN"
+                    accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    accessTokenExpiresUtc: "2026-07-03T12:27:08.312Z"
+                    accessTokenType: "bearer"
+              INPUT_WITH_NOTIFICATIONS_PRIVATE_KEY_JWT:
+                summary: Registration with notifications (PRIVATE_KEY_JWT credential)
+                description: |
+                  Create a registration and opt in for CloudEvent notifications using PRIVATE_KEY_JWT.
+                  Authorization server details (token endpoint, client ID, JWKS URL) are shared out-of-band
+                  between the consumer and the API provider during onboarding.
+                value:
+                  phoneNumber: "+123456789"
+                  terminatingCountryCode: 44
+                  displayName: "Company X Calling"
+                  customerId: "Customer1"
+                  verifyCallerAction: "DO_NOT_BRAND"
+                  sink: "https://endpoint.example.com/sink"
+                  sinkCredential:
+                    credentialType: "PRIVATE_KEY_JWT"
+
+      callbacks:
+        notifications:
+          "{$request.body#/sink}":
+            post:
+              tags:
+                - Call branded notifications callback
+              summary: Call branded notifications callback
+              description: |
+                Important: this endpoint is to be implemented by the API consumer.
+                The API provider will call this endpoint whenever a call associated with
+                a brand registration that opted in with `sink` is successfully branded.
+              operationId: postCallBrandedNotification
+              parameters:
+                - $ref: '#/components/parameters/x-correlator'
+              requestBody:
+                required: true
+                content:
+                  application/cloudevents+json:
+                    schema:
+                      $ref: '#/components/schemas/BrandRegistrationNotificationEvent'
+                    examples:
+                      CALL_BRANDED_EVENT:
+                        $ref: '#/components/examples/CALL_BRANDED_EVENT'
+              responses:
+                '204':
+                  description: Successful notification
+                  headers:
+                    x-correlator:
+                      $ref: '#/components/headers/x-correlator'
+                '400':
+                  $ref: '#/components/responses/Generic400'
+                '401':
+                  $ref: '#/components/responses/Generic401'
+                '403':
+                  $ref: '#/components/responses/Generic403'
+                '410':
+                  $ref: '#/components/responses/Generic410'
+                '429':
+                  $ref: '#/components/responses/Generic429'
+              security:
+                - {}
+                - notificationsBearerAuth: []
 
       responses:
         '201':
@@ -321,6 +398,13 @@ components:
       description: OpenID Connect authentication
       type: openIdConnect
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
+    notificationsBearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: "{$request.body#/sinkCredential.credentialType}"
+      description: |
+        Bearer token for notification delivery. Token format is determined
+        by `sinkCredential.credentialType` in the subscription request.
   parameters:
     x-correlator:
       name: x-correlator
@@ -453,6 +537,17 @@ components:
           $ref: '#/components/schemas/TerminatingCountryCode'
         campaignName:
           $ref: '#/components/schemas/CampaignName'
+        sink:
+          type: string
+          format: uri
+          maxLength: 2048
+          pattern: ^https:\/\/.+$
+          description: |
+            The HTTPS URL where event notifications for this registration will be delivered.
+            Omit this field (and `sinkCredential`) to create the registration without event notifications.
+          example: "https://endpoint.example.com/sink"
+        sinkCredential:
+          $ref: '#/components/schemas/SinkCredential'
 
     RegistrationRecord:
       type: object
@@ -483,6 +578,14 @@ components:
           $ref: '#/components/schemas/TerminatingCountryCode'
         campaignName:
           $ref: '#/components/schemas/CampaignName'
+        sink:
+          type: string
+          format: uri
+          maxLength: 2048
+          description: |
+            The sink URL registered for event notifications on this registration, if any.
+            `sinkCredential` is deliberately not echoed in responses for security reasons.
+          example: "https://endpoint.example.com/sink"
 
     RegistrationRecords:
       type: array
@@ -506,6 +609,175 @@ components:
         message:
           type: string
           description: Detailed error description
+
+    BrandRegistrationEventType:
+      type: string
+      description: |
+        Enum of event type strings emitted by the Brand Registration API.
+        Follows the CAMARA reverse-DNS convention `org.camaraproject.<api-name>.<event-version>.<event-name>`.
+      enum:
+        - org.camaraproject.brand-registration.v0.call-branded
+
+    BrandRegistrationNotificationEvent:
+      description: |
+        Notification event group for the Brand Registration API.
+        Extends the CloudEvent envelope and constrains `type` to the set of event types
+        defined by this API. Adding a new event type only requires updating
+        `BrandRegistrationEventType` and the discriminator mapping below — the CloudEvent
+        base never changes.
+      allOf:
+        - $ref: '#/components/schemas/CloudEvent'
+        - type: object
+          properties:
+            type:
+              $ref: '#/components/schemas/BrandRegistrationEventType'
+      discriminator:
+        propertyName: type
+        mapping:
+          org.camaraproject.brand-registration.v0.call-branded: '#/components/schemas/EventCallBranded'
+
+    EventCallBranded:
+      description: Event emitted when a call associated with a brand registration has been successfully branded.
+      allOf:
+        - $ref: '#/components/schemas/BrandRegistrationNotificationEvent'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/CallBrandedEventData'
+
+    CallBrandedEventData:
+      type: object
+      description: Event payload describing a successfully branded call.
+      required:
+        - registrationId
+        - brandedAt
+      properties:
+        registrationId:
+          $ref: '#/components/schemas/RegistrationId'
+        brandedAt:
+          type: string
+          format: date-time
+          description: Timestamp (RFC 3339, UTC) when the call was branded.
+          example: "2026-04-22T14:30:00Z"
+        strategy:
+          type: string
+          enum:
+            - SMS
+            - BRAND_DISPLAY
+          description: Branding strategy applied to the call.
+          example: "BRAND_DISPLAY"
+        displayNameUsed:
+          $ref: '#/components/schemas/DisplayName'
+        correlator:
+          $ref: '#/components/schemas/XCorrelator'
+
+    CloudEvent:
+      type: object
+      description: |
+        CloudEvents 1.0 specification envelope.
+        Stable base for all event notifications emitted by this API.
+      required:
+        - id
+        - source
+        - specversion
+        - type
+        - time
+      properties:
+        id:
+          type: string
+          maxLength: 256
+          description: Identifier of this event, unique within the source context.
+        source:
+          $ref: '#/components/schemas/Source'
+        type:
+          type: string
+          maxLength: 512
+          description: |
+            Identifies the event type. CAMARA APIs use reverse-DNS notation:
+            `org.camaraproject.<api-name>.<event-version>.<event-name>`.
+        specversion:
+          type: string
+          description: Version of the CloudEvents specification the event conforms to.
+          enum:
+            - "1.0"
+        datacontenttype:
+          type: string
+          description: Media type of the event payload encoding; MUST be `application/json` for CAMARA APIs.
+          enum:
+            - application/json
+        data:
+          type: object
+          description: Event details payload. Structure is defined by each concrete event schema.
+        time:
+          type: string
+          format: date-time
+          description: Timestamp (RFC 3339, UTC) when the event occurred.
+          example: "2026-04-22T14:30:00Z"
+
+    Source:
+      type: string
+      format: uri-reference
+      minLength: 1
+      maxLength: 2048
+      description: |
+        Identifies the context in which the event happened. MUST be a non-empty URI-reference.
+      example: "https://api.example.com/brand-registration/v0"
+
+    SinkCredential:
+      type: object
+      description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
+      properties:
+        credentialType:
+          type: string
+          enum:
+            - ACCESSTOKEN
+            - PRIVATE_KEY_JWT
+          description: The type of the credential - MUST be set to ACCESSTOKEN or PRIVATE_KEY_JWT.
+      discriminator:
+        propertyName: credentialType
+        mapping:
+          ACCESSTOKEN: '#/components/schemas/AccessTokenCredential'
+          PRIVATE_KEY_JWT: '#/components/schemas/PrivateKeyJWTCredential'
+      required:
+        - credentialType
+
+    AccessTokenCredential:
+      type: object
+      description: An access token credential. This type of credential is meant to be used by API Consumers that have limited capabilities to handle authorization requests.
+      allOf:
+        - $ref: '#/components/schemas/SinkCredential'
+        - type: object
+          properties:
+            accessToken:
+              type: string
+              maxLength: 4096
+              description: REQUIRED. An access token granting access to the target resource.
+            accessTokenExpiresUtc:
+              type: string
+              format: date-time
+              maxLength: 64
+              description: |
+                REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired.
+                It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have a time zone.
+              example: "2026-07-03T12:27:08.312Z"
+            accessTokenType:
+              type: string
+              enum:
+                - bearer
+              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
+          required:
+            - accessToken
+            - accessTokenExpiresUtc
+            - accessTokenType
+
+    PrivateKeyJWTCredential:
+      type: object
+      description: |
+        Use PRIVATE_KEY_JWT to obtain an access token. The authorization server information needed
+        for this type of sink credential (token endpoint, client ID, JWKS URL) is shared upfront
+        between the client and the CAMARA entity.
+      allOf:
+        - $ref: '#/components/schemas/SinkCredential'
 
   responses:
     SuccessfulRecord:
@@ -627,6 +899,10 @@ components:
                   code:
                     enum:
                       - INVALID_ARGUMENT
+                      - INVALID_PROTOCOL
+                      - INVALID_CREDENTIAL
+                      - INVALID_TOKEN
+                      - INVALID_SINK
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               summary: Invalid argument
@@ -635,6 +911,34 @@ components:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: Client specified an invalid argument, request body or query param.
+            GENERIC_400_INVALID_PROTOCOL:
+              summary: Invalid protocol
+              description: Invalid protocol for event notifications
+              value:
+                status: 400
+                code: INVALID_PROTOCOL
+                message: Only HTTPS is supported for notification delivery.
+            GENERIC_400_INVALID_CREDENTIAL:
+              summary: Invalid credential
+              description: Invalid sink credential type
+              value:
+                status: 400
+                code: INVALID_CREDENTIAL
+                message: Only ACCESSTOKEN or PRIVATE_KEY_JWT credential types are supported.
+            GENERIC_400_INVALID_TOKEN:
+              summary: Invalid token
+              description: The access token provided in sinkCredential is invalid
+              value:
+                status: 400
+                code: INVALID_TOKEN
+                message: The access token provided in sinkCredential is not valid.
+            GENERIC_400_INVALID_SINK:
+              summary: Invalid sink
+              description: The sink URL is invalid for the specified protocol
+              value:
+                status: 400
+                code: INVALID_SINK
+                message: The sink URL is not valid for the specified protocol.
     Generic401:
       description: Unauthorized
       headers:
@@ -823,6 +1127,32 @@ components:
                 status: 409
                 code: CONFLICT
                 message: Requested operation conflicts with existing data in the service platform
+    Generic410:
+      description: Gone
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 410
+                  code:
+                    enum:
+                      - GONE
+          examples:
+            GENERIC_410_GONE:
+              summary: Gone
+              description: The target notification sink is no longer available
+              value:
+                status: 410
+                code: GONE
+                message: The target resource is no longer available.
     CreateOrUpdateRegistrationUnprocessableEntity422:
       description: Unprocessable Content
       headers:
@@ -905,3 +1235,21 @@ components:
                 status: 503
                 code: UNAVAILABLE
                 message: "Service unavailable"
+
+  examples:
+    CALL_BRANDED_EVENT:
+      summary: Call branded event
+      description: Notification emitted when a call associated with a brand registration has been successfully branded.
+      value:
+        id: "83a0cf3a-f3ae-4f3b-9d3b-1e19c6e7f8a0"
+        source: "https://api.example.com/brand-registration/v0"
+        specversion: "1.0"
+        type: "org.camaraproject.brand-registration.v0.call-branded"
+        datacontenttype: "application/json"
+        time: "2026-04-22T14:30:00Z"
+        data:
+          registrationId: "ea77c42f-fa5e-4612-cb43-d502ae794832"
+          brandedAt: "2026-04-22T14:29:55Z"
+          strategy: "BRAND_DISPLAY"
+          displayNameUsed: "Company X Calling"
+          correlator: "b4c4b8a0-1234-5678-9abc-def012345678"

--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -647,18 +647,12 @@ components:
 
     CallBrandedEventData:
       type: object
-      description: Event payload describing a successfully branded call.
-      required:
-        - registrationId
-        - brandedAt
+      description: |
+        Event payload describing a successfully branded call.
+        The CloudEvent envelope's `source` carries the registration URL
+        (which encodes the `registrationId`) and `time` carries when the
+        call was branded — see the parent `BrandRegistrationNotificationEvent`.
       properties:
-        registrationId:
-          $ref: '#/components/schemas/RegistrationId'
-        brandedAt:
-          type: string
-          format: date-time
-          description: Timestamp (RFC 3339, UTC) when the call was branded.
-          example: "2026-04-22T14:30:00Z"
         strategy:
           type: string
           enum:
@@ -668,8 +662,14 @@ components:
           example: "BRAND_DISPLAY"
         displayNameUsed:
           $ref: '#/components/schemas/DisplayName'
-        correlator:
-          $ref: '#/components/schemas/XCorrelator'
+        preAnnounceCorrelator:
+          allOf:
+            - $ref: '#/components/schemas/XCorrelator'
+            - description: |
+                Optional. The `x-correlator` value from the originating `/pre-announce`
+                request when pre-announcement was used to initiate the branded call.
+                Absent when the call was branded automatically without pre-announcement
+                (e.g. via `verifyCallerAction` configured at registration).
 
     CloudEvent:
       type: object
@@ -720,8 +720,11 @@ components:
       minLength: 1
       maxLength: 2048
       description: |
-        Identifies the context in which the event happened. MUST be a non-empty URI-reference.
-      example: "https://api.example.com/brand-registration/v0"
+        Identifies the context in which the event happened. For Brand Registration
+        events, this MUST be the GET-able URL of the specific registration the
+        event pertains to, in the format
+        `{apiRoot}/brand-registration/{version}/registrations/{registrationId}`.
+      example: "https://service-provider.com/brand-registration/v0/registrations/ea77c42f-fa5e-4612-cb43-d502ae794832"
 
     SinkCredential:
       type: object
@@ -1242,14 +1245,12 @@ components:
       description: Notification emitted when a call associated with a brand registration has been successfully branded.
       value:
         id: "83a0cf3a-f3ae-4f3b-9d3b-1e19c6e7f8a0"
-        source: "https://api.example.com/brand-registration/v0"
+        source: "https://service-provider.com/brand-registration/v0/registrations/ea77c42f-fa5e-4612-cb43-d502ae794832"
         specversion: "1.0"
         type: "org.camaraproject.brand-registration.v0.call-branded"
         datacontenttype: "application/json"
         time: "2026-04-22T14:30:00Z"
         data:
-          registrationId: "ea77c42f-fa5e-4612-cb43-d502ae794832"
-          brandedAt: "2026-04-22T14:29:55Z"
           strategy: "BRAND_DISPLAY"
           displayNameUsed: "Company X Calling"
-          correlator: "b4c4b8a0-1234-5678-9abc-def012345678"
+          preAnnounceCorrelator: "b4c4b8a0-1234-5678-9abc-def012345678"

--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -662,14 +662,16 @@ components:
           example: "BRAND_DISPLAY"
         displayNameUsed:
           $ref: '#/components/schemas/DisplayName'
-        preAnnounceCorrelator:
-          allOf:
-            - $ref: '#/components/schemas/XCorrelator'
-            - description: |
-                Optional. The `x-correlator` value from the originating `/pre-announce`
-                request when pre-announcement was used to initiate the branded call.
-                Absent when the call was branded automatically without pre-announcement
-                (e.g. via `verifyCallerAction` configured at registration).
+        preAnnouncementId:
+          type: string
+          format: uuid
+          description: |
+            Optional. The identifier of the originating pre-announcement, as returned
+            in the `AnnouncementInfo` response of `POST /pre-announce` (verified-caller API).
+            Present when pre-announcement was used to initiate the branded call.
+            Absent when the call was branded automatically without pre-announcement
+            (e.g. via `verifyCallerAction` configured at registration).
+          example: "9e765f76-8037-4e5f-ba5d-e0c87c09a320"
 
     CloudEvent:
       type: object
@@ -1253,4 +1255,4 @@ components:
         data:
           strategy: "BRAND_DISPLAY"
           displayNameUsed: "Company X Calling"
-          preAnnounceCorrelator: "b4c4b8a0-1234-5678-9abc-def012345678"
+          preAnnouncementId: "9e765f76-8037-4e5f-ba5d-e0c87c09a320"


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Adds an implicit-subscription callback to `POST /registrations` so API consumers receive asynchronous notifications when their branded calls are successfully branded. Follows the pattern established by QualityOnDemand and other CAMARA APIs using implicit subscriptions.

Key design decisions (per discussion in #73):

- **Implicit subscription** (not explicit) — aligns with the QoD pattern cited by @alpaycetin74 as a better fit and more lightweight than a dedicated `/subscriptions` resource.

- **Linked to brand-registration, not pre-announce** — since calls can be branded without pre-announcement (when `verifyCallerAction` is set at registration), the notification must be tied to the registration lifecycle.

- **Event type:** `org.camaraproject.brand-registration.v0.call-branded`

- **`sink` and `sinkCredential` are optional opt-in fields** on the existing `CreateOrUpdateRegistrationRequest`. Omitting them creates the registration without notifications.

#### Event data payload

```yaml
CallBrandedEventData:
  required: [registrationId, brandedAt]
  properties:
    registrationId    # which registration
    brandedAt         # timestamp
    strategy          # SMS | BRAND_DISPLAY (optional context)
    displayNameUsed   # what was shown to the callee (optional context)
    correlator        # x-correlator from pre-announce, if applicable (optional - per @rartych's suggestion)
```

The event payload deliberately omits the callee phone number on data-minimization grounds: the consumer of this notification is the enterprise (API consumer), and they can correlate with their own outbound call records using the timestamp. The callee is typically not a subscriber of the VerifiedCaller service. Open to revisiting in a future `v1` event if a concrete use case emerges.

Thanks @GillesInnov35 for raising the consumer-side context need — `correlator` (from @rartych's suggestion) covers the common correlation case when pre-announcement is used.

#### Which issue(s) this PR fixes:

Fixes #73

#### Special notes for reviewers:

This is marked as **Draft** to invite design-level feedback before finalizing.

A few things to flag:

1. **Commonalities bump** — `x-camara-commonalities` bumped from `0.6` to `0.7.0` to align with the CloudEvents/sink/sinkCredential schemas from r4.1.

2. **PUT /registrations/{registrationId} also accepts `sink`/`sinkCredential`** — because it shares `CreateOrUpdateRegistrationRequest`. This lets consumers update their notification configuration alongside other registration changes. Happy to split into separate schemas if reviewers prefer POST-only.

3. **`Generic400` extended** with `INVALID_PROTOCOL`, `INVALID_CREDENTIAL`, `INVALID_TOKEN`, `INVALID_SINK` codes so a malformed `sink` or bad credential returns a specific error rather than a generic `INVALID_ARGUMENT`.

4. **Inlined schemas (not external `$ref`)** — follows the current CAMARA convention (QoD, SimSwap, SessionInsights all inline `CloudEvent`, `SinkCredential`, etc.). The `sample-implicit-events.yaml` template (Commonalities #612, merged 2026-04-21) uses `../common/` refs, but no production API has adopted that pattern yet and VerifiedCaller has no `code/common/` directory. Happy to migrate to external refs when the broader ecosystem adopts the new pattern.

5. **No tests yet** — I'd prefer to land the API design first and follow up with a separate PR for `.feature` test definitions once the schema is agreed.


#### Changelog input

```
Added optional `sink` and `sinkCredential` fields to POST /registrations for opt-in event notifications via OpenAPI callbacks (implicit-subscription pattern). Added `org.camaraproject.brand-registration.v0.call-branded` event for notifying API consumers when calls are branded.
```

#### Additional documentation

- Related issue: [#73](https://github.com/camaraproject/VerifiedCaller/issues/73)
- Reference pattern: [QualityOnDemand implicit subscription](https://github.com/camaraproject/QualityOnDemand/blob/main/code/API_definitions/quality-on-demand.yaml)
- Commonalities template: [sample-implicit-events.yaml](https://github.com/camaraproject/Commonalities/blob/main/artifacts/api-templates/sample-implicit-events.yaml)
