### PR TITLE
Enhance brand-registration.yaml with new event schemas

### DIFF
--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -174,6 +174,8 @@ paths:
                     examples:
                       CALL_BRANDED_EVENT:
                         $ref: '#/components/examples/CALL_BRANDED_EVENT'
+                      BRAND_REGISTRATION_STATUS_EVENT:
+                        $ref: '#/components/examples/BRAND_REGISTRATION_STATUS_EVENT'
               responses:
                 '204':
                   description: Successful notification
@@ -1288,3 +1290,17 @@ components:
           strategy: "BRAND_DISPLAY"
           displayNameUsed: "Company X Calling"
           preAnnouncementId: "9e765f76-8037-4e5f-ba5d-e0c87c09a320"
+
+    BRAND_REGISTRATION_STATUS_EVENT:
+      summary: Registration Status Changed event
+      description: Notification emitted when a brand registration status has changed.
+      value:
+        id: "83a0cf3a-f3ae-4f3b-9d3b-1e19c6e7f8a0"
+        source: "https://service-provider.com/brand-registration/v0/registrations"
+        specversion: "1.0"
+        type: "org.camaraproject.brand-registration.v0.status-changed"
+        datacontenttype: "application/json"
+        time: "2026-04-22T14:30:00Z"
+        data:
+          registrationId: "ea77c42f-fa5e-4612-cb43-d502ae794832"
+          status: "pending"

--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -620,6 +620,7 @@ components:
         Follows the CAMARA reverse-DNS convention `org.camaraproject.<api-name>.<event-version>.<event-name>`.
       enum:
         - org.camaraproject.brand-registration.v0.call-branded
+        - org.camaraproject.brand-registration.v0.status-changed
 
     BrandRegistrationNotificationEvent:
       description: |
@@ -638,6 +639,7 @@ components:
         propertyName: type
         mapping:
           org.camaraproject.brand-registration.v0.call-branded: '#/components/schemas/EventCallBranded'
+          org.camaraproject.brand-registration.v0.status-changed: '#/components/schemas/EventStatusChanged'
 
     EventCallBranded:
       description: Event emitted when a call associated with a brand registration has been successfully branded.
@@ -647,6 +649,15 @@ components:
           properties:
             data:
               $ref: '#/components/schemas/CallBrandedEventData'
+
+    EventStatusChanged:
+      description: Event emitted when a call associated with a brand registration status changed.
+      allOf:
+        - $ref: '#/components/schemas/BrandRegistrationNotificationEvent'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/StatusChangedEventData'
 
     CallBrandedEventData:
       type: object
@@ -677,6 +688,24 @@ components:
             Absent when the call was branded automatically without pre-announcement
             (e.g. no `verifyCallerAction` was configured at registration).
           example: "9e765f76-8037-4e5f-ba5d-e0c87c09a320"
+
+    StatusChangedEventData:
+      type: object
+      description: |
+        Event payload describing a Registration status changed.
+        The CloudEvent envelope's `time` carries when the status has been changed.
+      required:
+        - registrationId
+      properties:
+        registrationId:
+          $ref: '#/components/schemas/RegistrationId'
+        status:
+          type: string
+          enum:
+            - SMS
+            - BRAND_DISPLAY
+          description: Branding strategy applied to the call.
+          example: "active"
 
     CloudEvent:
       type: object

--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -651,7 +651,7 @@ components:
               $ref: '#/components/schemas/CallBrandedEventData'
 
     EventStatusChanged:
-      description: Event emitted when a call associated with a brand registration status changed.
+      description: Event emitted when the status of a brand registration changes.
       allOf:
         - $ref: '#/components/schemas/BrandRegistrationNotificationEvent'
         - type: object
@@ -696,6 +696,7 @@ components:
         The CloudEvent envelope's `time` carries when the status has been changed.
       required:
         - registrationId
+        - status
       properties:
         registrationId:
           $ref: '#/components/schemas/RegistrationId'

--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -701,11 +701,9 @@ components:
           $ref: '#/components/schemas/RegistrationId'
         status:
           type: string
-          enum:
-            - SMS
-            - BRAND_DISPLAY
-          description: Branding strategy applied to the call.
-          example: "active"
+          enum: [pending, active, inactive]
+          description: Status of the registration.
+          example: "pending"
 
     CloudEvent:
       type: object

--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -701,10 +701,7 @@ components:
         registrationId:
           $ref: '#/components/schemas/RegistrationId'
         status:
-          type: string
-          enum: [pending, active, inactive]
-          description: Status of the registration.
-          example: "pending"
+          $ref: '#/components/schemas/Status'
 
     CloudEvent:
       type: object


### PR DESCRIPTION
Added EventStatusChanged and StatusChangedEventData schemas to the Brand Registration API definition.

#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature


#### What this PR does / why we need it:
add a new event type org.camaraproject.brand-registration.v0.status-changed to registration notification flows.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #89 


