### PR TITLE
Add optional filter query parameters to GET /registrations (#87)

### DIFF
--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -223,13 +223,40 @@ paths:
       tags:
         - Read Brand registration
       summary: Read existing brand registrations from the service platform
-      description: Read existing brand registrations from the service platform.
+      description: |
+        Read existing brand registrations from the service platform.
+
+        ## Filtering
+
+        The following query parameters are RECOMMENDED filters for this
+        operation. They are all optional. API providers MAY implement any
+        subset of them based on their capabilities; the supported set for a
+        given provider is documented on that provider's Exposition Gateway
+        "Getting Started" page (filter support is not intended to be
+        discovered through HTTP error responses).
+
+        - `customerId` - filter by enterprise/brand owner identifier.
+        - `displayName` - filter by the display name registered for the brand.
+        - `status` - filter by registration status.
+        - `terminatingCountryCode` - filter by terminating country code.
+
+        When more than one filter is provided, results MUST match all of
+        them (logical AND).
+
+        Regardless of the filters supplied, an authenticated client only
+        ever receives registrations it owns; filters narrow the result set,
+        they never expose another tenant's data. In particular, `customerId`
+        is interpreted within the scope of the authenticated client.
       operationId: readRegistrations
       parameters:
         - $ref: '#/components/parameters/x-correlator'
         - $ref: '#/components/parameters/Page'
         - $ref: '#/components/parameters/PerPage'
         - $ref: '#/components/parameters/Seek'
+        - $ref: '#/components/parameters/CustomerIdFilter'
+        - $ref: '#/components/parameters/DisplayNameFilter'
+        - $ref: '#/components/parameters/StatusFilter'
+        - $ref: '#/components/parameters/TerminatingCountryCodeFilter'
       responses:
         '200':
           $ref: '#/components/responses/SuccessfulRecords'
@@ -437,6 +464,36 @@ components:
       description: Indicates the last entry read, to create the next/previous subset of entries in the response of the current query.
       schema:
         type: string
+    CustomerIdFilter:
+      name: customerId
+      in: query
+      required: false
+      description: |
+        Optional filter. Restrict results to registrations matching the given `customerId`.
+        Always interpreted within the scope of the authenticated client.
+      schema:
+        $ref: '#/components/schemas/CustomerId'
+    DisplayNameFilter:
+      name: displayName
+      in: query
+      required: false
+      description: Optional filter. Restrict results to registrations matching the given `displayName`.
+      schema:
+        $ref: '#/components/schemas/DisplayName'
+    StatusFilter:
+      name: status
+      in: query
+      required: false
+      description: Optional filter. Restrict results to registrations in the given `status`.
+      schema:
+        $ref: '#/components/schemas/Status'
+    TerminatingCountryCodeFilter:
+      name: terminatingCountryCode
+      in: query
+      required: false
+      description: Optional filter. Restrict results to registrations matching the given `terminatingCountryCode`.
+      schema:
+        $ref: '#/components/schemas/TerminatingCountryCode'
 
   headers:
     x-correlator:


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Adds four optional query parameters to `GET /registrations` so API consumers can narrow the result set when listing brand registrations. Implements what was discussed and agreed in #87.

Filters added (each reuses the existing schema for the corresponding field on `RegistrationRecord`):

- `customerId` - filter by enterprise/brand owner identifier
- `displayName` - filter by the display name registered for the brand
- `status` - filter by registration status
- `terminatingCountryCode` - filter by terminating country code

#### Which issue(s) this PR fixes:

Fixes #87

#### Special notes for reviewers:

This is marked as **Draft** for a final wording check before review.

A few things to flag:

1. **No new schemas** - each query parameter `$ref`s the existing schema for the matching field on `RegistrationRecord` (`CustomerId`, `DisplayName`, `Status`, `TerminatingCountryCode`). Keeps the change purely additive.

2. **Match semantics intentionally unspecified** - the spec doesn't mandate exact / case-insensitive / prefix matching. Left to providers, consistent with the "MAY implement" posture. Happy to tighten this if the WG prefers a normative rule.

3. **Parameters defined under `components.parameters`** - matches the existing `Page` / `PerPage` / `Seek` style in this file rather than inline definitions.

4. **No changes** to response schemas, examples, error responses, pagination, security, or any other operation. `x-camara-commonalities` not bumped.

#### Changelog input

```
Added optional `customerId`, `displayName`, `status` and `terminatingCountryCode` query parameters to `GET /registrations` as RECOMMENDED filters. Providers MAY implement any subset; the supported filter set is documented per provider on the Exposition Gateway "Getting Started" page rather than discovered through HTTP error responses.
```

#### Additional documentation

- Related discussion: [#87](https://github.com/camaraproject/VerifiedCaller/issues/87)
- CAMARA guidance on sensitive data in query parameters (basis for excluding `phoneNumber`)
