### PR TITLE
Add maxLength constraint to CustomerId schema (#97)

### DIFF
--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -535,6 +535,7 @@ components:
 
     CustomerId:
       type: string
+      maxLength: 64
       description: Unique customer identifier for a brand
       example: "Customer1"
 


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Adds a `maxLength: 64` constraint to the `CustomerId` schema in `brand-registration.yaml`. The field was previously an unbounded `type: string`. Implements what was discussed and agreed in #97.

The CAMARA API Design Guide requires string properties to be constrained using either `maxLength` or an `enum`

#### Which issue(s) this PR fixes:

Fixes #97

#### Special notes for reviewers:

Minor correction - single-line schema change, no behavioural impact.

A couple of things to flag:

1. **Consistent with the existing precedent in this file** - `DisplayName` directly below already uses `maxLength` (`32`), with no regex `pattern`. This change follows the same shape: `maxLength` only, placed right after `type`.

2. **Value (`64`)** - covers a UUID (36 chars) with headroom for tenant-prefixed identifiers.

3. **No changes** to examples, descriptions, other schemas.