### PR TITLE
Add createdAt and updatedAt fields to brand registration

### DIFF
--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -18,6 +18,8 @@ info:
     * **phoneNumber** and **phoneNumberAlternate**: A pair of E.164 numbers representing the caller. Depending on the caller's networks access setup , only phoneNumber or both phoneNumber & phoneNumberAlternate may be used to uniquely identify the caller. The values typically correspond to parameters used in telecom signalling protocols, e.g. PAI and FROM headers in SIP.
     * **status**: Status of the registration.
     * **expiresAt**: The date in RFC 3339 / ISO 8601 compliant format when the brand registration is scheduled to expire. Registration status is moved to ``expired``.
+    * **createdAt**: Timestamp at which the Brand Registration has been created. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+    * **updatedAt**: Timestamp at which the Brand Registration has been last updated. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
     * **displayName**: A human-readable string that is to be displayed to the callee on their device screen instead of the calling number.
     * **displayAsset**: A visual asset (e.g. a logo, image or video) that is to be displayed to the callee on their device screen instead of the calling number. Support of the visual asset depends on the service provider and callee's device. If the service provider does not support the parameter, it SHALL clearly document the limitation and SHOULD silently ignore the parameter if received.
     * **customerId** : A string to represent the owner of the displayName, e.g. a commercial brand or an institution.
@@ -259,6 +261,8 @@ paths:
         - `customerId` - filter by enterprise/brand owner identifier.
         - `displayName` - filter by the display name registered for the brand.
         - `status` - filter by registration status.
+        - `createdAt` - filter by createdAt date-time.
+        - `updatedAt` - filter by updatedAt date-time.
         - `expiresAt` - filter by expiresAt date.
         - `terminatingCountryCode` - filter by terminating country code.
         - `callPurpose` - filter by call purpose.
@@ -278,6 +282,8 @@ paths:
         - $ref: '#/components/parameters/CustomerIdFilter'
         - $ref: '#/components/parameters/DisplayNameFilter'
         - $ref: '#/components/parameters/StatusFilter'
+        - $ref: '#/components/parameters/CreatedAtFilter'
+        - $ref: '#/components/parameters/UpdatedAtFilter'
         - $ref: '#/components/parameters/ExpiresAtFilter'
         - $ref: '#/components/parameters/TerminatingCountryCodeFilter'
         - $ref: '#/components/parameters/CallPurposeFilter'
@@ -490,6 +496,20 @@ components:
       description: Optional filter. Restrict results to registrations in the given `status`.
       schema:
         $ref: '#/components/schemas/Status'
+    CreatedAtFilter:
+      name: createdAt
+      in: query
+      required: false
+      description: Optional filter. Restrict results to registrations matching the given createdAt date-time.
+      schema:
+        $ref: '#/components/schemas/CreatedAt'
+    UpdatedAtFilter:
+      name: updatedAt
+      in: query
+      required: false
+      description: Optional filter. Restrict results to registrations matching the given updatedAt date-time.
+      schema:
+        $ref: '#/components/schemas/UpdatedAt'
     ExpiresAtFilter:
       name: expiresAt
       in: query
@@ -554,6 +574,20 @@ components:
       format: date
       example: "2023-07-03"
       maxLength: 10
+
+    CreatedAt:
+      type: string
+      format: date-time
+      maxLength: 64
+      description: Timestamp at which the Brand Registration has been created. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+      example: "2018-04-05T17:31:00Z"
+
+    UpdatedAt:
+      type: string
+      format: date-time
+      maxLength: 64
+      description: Timestamp at which the Brand Registration has been last updated. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+      example: "2018-04-05T17:31:00Z"
 
     CustomerId:
       type: string
@@ -690,6 +724,10 @@ components:
           $ref: '#/components/schemas/PhoneNumber'
         status:
           $ref: '#/components/schemas/Status'
+        createdAt:
+          $ref: '#/components/schemas/CreatedAt'
+        updatedAt:
+          $ref: '#/components/schemas/UpdatedAt'
         expiresAt:
           $ref: '#/components/schemas/ExpiresAt'
         displayName:
@@ -734,29 +772,6 @@ components:
             $ref: '#/components/schemas/RegistrationRecord'
         pagination:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/Pagination"
-
-    ErrorInfo:
-      description: Common schema for errors
-      type: object
-      required:
-        - status
-        - code
-        - message
-      properties:
-        status:
-          type: integer
-          format: int32
-          minimum: 100
-          maximum: 599
-          description: HTTP status code returned along with this error response
-        code:
-          type: string
-          description: Code given to this error
-          maxLength: 96
-        message:
-          type: string
-          description: Detailed error description
-          maxLength: 512
 
     BrandRegistrationEventType:
       type: string
@@ -1116,7 +1131,7 @@ components:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -1175,7 +1190,7 @@ components:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -1209,7 +1224,7 @@ components:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:
@@ -1251,7 +1266,7 @@ components:
         application/json:
           schema:
             allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
               - type: object
                 properties:
                   status:

--- a/code/API_definitions/brand-registration.yaml
+++ b/code/API_definitions/brand-registration.yaml
@@ -261,8 +261,10 @@ paths:
         - `customerId` - filter by enterprise/brand owner identifier.
         - `displayName` - filter by the display name registered for the brand.
         - `status` - filter by registration status.
-        - `createdAt` - filter by createdAt date-time.
-        - `updatedAt` - filter by updatedAt date-time.
+        - `createdAt.lte` - filter by lower createdAt date-time.
+        - `createdAt.gte` - filter by greater createdAt date-time.
+        - `updatedAt.lte` - filter by lower updatedAt date-time.
+        - `updatedAt.gte` - filter by greater updatedAt date-time.
         - `expiresAt` - filter by expiresAt date.
         - `terminatingCountryCode` - filter by terminating country code.
         - `callPurpose` - filter by call purpose.
@@ -282,8 +284,10 @@ paths:
         - $ref: '#/components/parameters/CustomerIdFilter'
         - $ref: '#/components/parameters/DisplayNameFilter'
         - $ref: '#/components/parameters/StatusFilter'
-        - $ref: '#/components/parameters/CreatedAtFilter'
-        - $ref: '#/components/parameters/UpdatedAtFilter'
+        - $ref: '#/components/parameters/CreatedAtBeforeFilter'
+        - $ref: '#/components/parameters/CreatedAtAfterFilter'
+        - $ref: '#/components/parameters/UpdatedAtBeforeFilter'
+        - $ref: '#/components/parameters/UpdatedAtAfterFilter'
         - $ref: '#/components/parameters/ExpiresAtFilter'
         - $ref: '#/components/parameters/TerminatingCountryCodeFilter'
         - $ref: '#/components/parameters/CallPurposeFilter'
@@ -496,18 +500,32 @@ components:
       description: Optional filter. Restrict results to registrations in the given `status`.
       schema:
         $ref: '#/components/schemas/Status'
-    CreatedAtFilter:
-      name: createdAt
+    CreatedAtBeforeFilter:
+      name: createdAt.lte
       in: query
       required: false
-      description: Optional filter. Restrict results to registrations matching the given createdAt date-time.
+      description: Optional filter. Restrict results to registrations for which creation date-time is lower or equal than the given createdAt date-time.
       schema:
         $ref: '#/components/schemas/CreatedAt'
-    UpdatedAtFilter:
-      name: updatedAt
+    CreatedAtAfterFilter:
+      name: createdAt.gte
       in: query
       required: false
-      description: Optional filter. Restrict results to registrations matching the given updatedAt date-time.
+      description: Optional filter. Restrict results to registrations for which creation date-time is greater or equal than the given createdAt date-time.
+      schema:
+        $ref: '#/components/schemas/CreatedAt'
+    UpdatedAtBeforeFilter:
+      name: updatedAt.lte
+      in: query
+      required: false
+      description: Optional filter. Restrict results to registrations for which last update date-time is lower or equal than the given updatedAt date-time.
+      schema:
+        $ref: '#/components/schemas/UpdatedAt'
+    UpdatedAtAfterFilter:
+      name: updatedAt.gte
+      in: query
+      required: false
+      description: Optional filter. Restrict results to registrations for which last update date-time is greater or equal than the given updatedAt date-time.
       schema:
         $ref: '#/components/schemas/UpdatedAt'
     ExpiresAtFilter:


### PR DESCRIPTION
Added createdAt and updatedAt fields with filters to the brand registration API definition.

#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:
include 2 new fields createdAt and updatedAt to the brand registration API definition allowing full management of customer registrations.
To be more useful for operational purposes, fields format is date-time (e.g. 2026-07-16T11:51:30+03:00)

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #123 

